### PR TITLE
feat: Expose `Error` type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod reader;
 mod util;
 mod writer;
 
+pub use crate::error::Error;
 pub use crate::header::CarHeader;
 pub use crate::reader::CarReader;
 pub use crate::writer::CarWriter;


### PR DESCRIPTION
This is useful for libraries that make use of `iroh-car` and also expose `thiserror` error types.